### PR TITLE
Bump `clone-deep`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "arr-union": "^3.1.0",
-    "clone-deep": "^0.2.4",
+    "clone-deep": "^4.0.1",
     "kind-of": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade `clone-deep` to the latest version, so that it [doesn't throw a webpack warning](https://github.com/jonschlinkert/clone-deep/issues/3).