### PR TITLE
Updating clone-deep

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "arr-union": "^3.1.0",
-    "clone-deep": "^0.2.4",
+    "clone-deep": "^4.0.1",
     "kind-of": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
There seems to be an issue with this project and https://github.com/vercel/ncc/issues/500, which is cause by the older version of clone deep. This PR upgrades clone-deep to the latest version.