### PR TITLE
Updated clone-deep to point to latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "arr-union": "^3.1.0",
-    "clone-deep": "^0.2.4",
+    "clone-deep": "^4.0.1",
     "kind-of": "^3.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "arr-union": "^3.1.0",
-    "clone-deep": "^0.2.4",
+    "clone-deep": "^4.0.1",
     "kind-of": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating clone-deep as its causing issues with https://github.com/vercel/ncc. 