### PR TITLE
bump clone-deep dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "arr-union": "^3.1.0",
-    "clone-deep": "^0.2.4",
+    "clone-deep": "^4.0.1",
     "kind-of": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm using a package which uses merge-deep, which I'm then trying to webpack. So opening this PR to bump the clone-deep dependency to get the fix (from 2015!): https://github.com/jonschlinkert/clone-deep/commit/2d977fcd063a68981588d637e9f2e2157ad66f87 

Hopefully CI will tell me if this blows up.